### PR TITLE
Render name on layout elements

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -11,6 +11,7 @@ function makePrimitive(name, DefaultComponent, display, defaultStyle) {
         component: Component = DefaultComponent,
         elRef,
         style: propStyle,
+        name: propName,
         className,
         ...otherProps
       } = this.props;
@@ -25,6 +26,7 @@ function makePrimitive(name, DefaultComponent, display, defaultStyle) {
         <Component
           ref={elRef}
           className={cx(className)}
+          name={propName}
           {...props}
           style={{...style, ...propStyle}}
         />


### PR DESCRIPTION
### why?

End-to-end tests often use that pattern to find elements in the DOM.