### PR TITLE
Disable normalization of urls

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -11,6 +11,7 @@ module.exports = {
     },
     cssnano: {
       normalizeUrl: false,
+      discardEmpty: false,
     },
   },
 };


### PR DESCRIPTION
Includes some fixes to some bugs that were introduced during the recent revamp to the build process of UI.

## cssnano
- Disable `normalizeUrl`. Ensures that 'url()' imports aren't transformed, and remain relative to the component directory.
- Disable `discardEmpty` to keep all of our empty classes. We use empty classes as a shim. For example, it allows 'none' to be passed through as a color prop, which will result in `text__color-none` class being added.