### PR TITLE
A more `static` PaperMenuItem

### DIFF
--- a/src/components/paper-menu/__examples__/paper-menu.examples.js
+++ b/src/components/paper-menu/__examples__/paper-menu.examples.js
@@ -13,10 +13,10 @@ export const examples = [
   },
 ];
 
-const InnerLayoutForDemo = props => (
-  <Flex flexDirection="column">
-    <Text size="medium" color="slate">
-      {props.children}
+const InnerLayoutForDemo = ({children, ...textProps}) => (
+  <Flex flexDirection="column" padding={[8, 0]}>
+    <Text size="medium" color="slate" {...textProps}>
+      {children}
     </Text>
   </Flex>
 );
@@ -50,6 +50,12 @@ export class Example extends React.Component {
           sticky={{width: '300px'}}
           open={this.state.open}
         >
+          <PaperMenuItem static={true}>
+            <InnerLayoutForDemo size="extra-small">
+              Options can be buttons, links, or just static labels like this
+              one.
+            </InnerLayoutForDemo>
+          </PaperMenuItem>
           <PaperMenuItem
             minWidth={300}
             title="Switch teams"
@@ -64,6 +70,7 @@ export class Example extends React.Component {
           <PaperMenuItem
             component="a"
             href="http://kalohq.com"
+            target="_blank"
             title="As a link"
           >
             <InnerLayoutForDemo>This is actually a link</InnerLayoutForDemo>

--- a/src/components/paper-menu/components/paper-menu-item.js
+++ b/src/components/paper-menu/components/paper-menu-item.js
@@ -12,7 +12,7 @@ const StyledPaperMenuItem = styled(Box)`
   align-content: center;
   flex-direction: row;
   background-color: ${props => props.theme.colors.white};
-  cursor: ${props => (props.disabled ? 'default' : 'pointer')};
+  cursor: ${props => (props.disabled || props.static ? 'default' : 'pointer')};
   opacity: ${props => (props.disabled ? 0.5 : 1)};
   border-bottom: 1px solid ${props => props.theme.colors.grey300};
   transition: all 0.2s ease-in;
@@ -25,7 +25,11 @@ const StyledPaperMenuItem = styled(Box)`
 
   &:hover {
     ${props =>
-      !props.disabled && css`background-color: ${props.theme.colors.grey300};`};
+      !props.disabled &&
+      !props.static &&
+      css`
+        background-color: ${props.theme.colors.grey300};
+      `};
   }
 
   ${props =>


### PR DESCRIPTION
* hides the hover background in `static` 🧐
* removes the pointer cursor ☝️
* shows it off in the story 💅

### after

![3298476387](https://user-images.githubusercontent.com/4624660/39998727-4d5a8bc2-5787-11e8-9615-01dbf936d6fd.gif)
