### PR TITLE
Remove breakpoints and space from theme

### DIFF
--- a/src/components/theme/theme.js
+++ b/src/components/theme/theme.js
@@ -11,7 +11,6 @@ import tokens from '../../design-tokens/tokens.theme.js';
  */
 
 const theme = {
-  space: [0, 8, 16, 32, 64],
   ...tokens,
 };
 


### PR DESCRIPTION
Removes two keys (`space`, and `breakpoints`) from the exported theme.

These are legacy, and are overriding the `breakpoints` object which is added to the theme in the frontend.