### PR TITLE
Silence jest errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "rimraf lib && npm run compile",
     "compile": "npm run generate:tokens && npm run generate:icons && gulp build-production",
-    "test": "jest",
+    "test": "jest --silent",
     "release": "np --no-yarn --no-cleanup --any-branch",
     "typecheck": "flow",
     "lint": "eslint src",


### PR DESCRIPTION
Silences errors from Jest, which should make running them slightly easier to read.

The current error that we're seeing is from a dependency.

```
console.warn node_modules/react/lib/lowPriorityWarning.js:38
      Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
    console.warn node_modules/react/lib/lowPriorityWarning.js:38
      Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class
```