### PR TITLE
Add alignment to buttons

### DIFF
--- a/src/components/button-group/__examples__/button-group.examples.js
+++ b/src/components/button-group/__examples__/button-group.examples.js
@@ -32,4 +32,15 @@ export const examples = [
       </ButtonGroup>
     ),
   },
+  {
+    title: 'Alignment',
+    description:
+      'Buttons can be aligned left, center, or right. Most button groups should be aligned right',
+    render: () => (
+      <ButtonGroup spacing={true} align="right">
+        <Button variant="tertiary">Cancel</Button>
+        <Button variant="primary">Create Project</Button>
+      </ButtonGroup>
+    ),
+  },
 ];

--- a/src/components/button-group/button-group.core.css
+++ b/src/components/button-group/button-group.core.css
@@ -7,3 +7,15 @@
 .ui-button-group--wide {
   width: 100%;
 }
+
+.ui-button-group--align-left {
+  justify-content: flex-start;
+}
+
+.ui-button-group--align-center {
+  justify-content: center;
+}
+
+.ui-button-group--align-right {
+  justify-content: flex-end;
+}

--- a/src/components/button-group/button-group.js
+++ b/src/components/button-group/button-group.js
@@ -21,10 +21,20 @@ type Props = {
   spacing?: boolean,
   /** Reverses the order of child buttons */
   reverse?: boolean,
+  /** X Alignment of the buttons */
+  align?: 'left' | 'center' | 'right',
 };
 
 export default function ButtonGroup(props: Props) {
-  const {children, wide = true, flex, spacing, reverse, ...otherProps} = props;
+  const {
+    children,
+    wide = true,
+    flex,
+    spacing,
+    reverse,
+    align,
+    ...otherProps
+  } = props;
 
   const childrenInOrder =
     reverse && isArray(children) ? [...children].reverse() : children;
@@ -32,6 +42,7 @@ export default function ButtonGroup(props: Props) {
   const _classNames = cx({
     [coreStyles['ui-button-group']]: true,
     [coreStyles['ui-button-group--wide']]: wide,
+    [coreStyles[`ui-button-group--align-${String(align)}`]]: align,
   });
 
   return (


### PR DESCRIPTION
Provides an easy way to align buttons in a button group `left | center | right`.