### PR TITLE
Allow native DOM properties on an <input>

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -96,6 +96,8 @@ type TProps = {
   fullWidth?: boolean,
   /** An icon to displau to the left of the input */
   icon?: string,
+  /** Native DOM properties to pass to the input element */
+  properties?: Object,
 };
 
 type TState = {
@@ -201,6 +203,7 @@ export default class Input extends PureComponent<TProps, TState> {
       addonPrefix,
       addonSuffix,
       icon,
+      properties,
       ...otherProps
     } = this.props;
 
@@ -252,6 +255,7 @@ export default class Input extends PureComponent<TProps, TState> {
         )}
         <input
           {...cleanProps(otherProps)}
+          {...properties}
           /** Other Props */
           ref={focusOnMount ? _focusOnMount : inputRef}
           style={_styles}


### PR DESCRIPTION
Allows using things like native `autocomplete`, `autofocus`, `tabindex` etc.

For example, `<Input properties={{autocomplete: 'off'}} />` will prevent this:

<img width="292" alt="screen shot 2018-08-21 at 13 04 45" src="https://user-images.githubusercontent.com/4624660/44398570-a8041880-a544-11e8-916c-c8930301f069.png">
