### PR TITLE
Use correct component name for unique ids

### DIFF
--- a/src/components/button-dropdown/__tests__/__snapshots__/button-dropdown.test.js.snap
+++ b/src/components/button-dropdown/__tests__/__snapshots__/button-dropdown.test.js.snap
@@ -222,12 +222,12 @@ exports[`ButtonDropdown should render with a checkbox 1`] = `
       <input
         checked={false}
         disabled={false}
-        id="toggleButton1"
+        id="checkbox1"
         onChange={[Function]}
         type="checkbox"
       />
       <label
-        htmlFor="toggleButton1"
+        htmlFor="checkbox1"
         onClick={[Function]}
       />
     </div>
@@ -264,12 +264,12 @@ exports[`ButtonDropdown should render with a checkbox 1`] = `
       <input
         checked={false}
         disabled={false}
-        id="toggleButton2"
+        id="checkbox2"
         onChange={[Function]}
         type="checkbox"
       />
       <label
-        htmlFor="toggleButton2"
+        htmlFor="checkbox2"
         onClick={[Function]}
       />
     </div>

--- a/src/components/checkbox/__tests__/__snapshots__/checkbox.test.js.snap
+++ b/src/components/checkbox/__tests__/__snapshots__/checkbox.test.js.snap
@@ -60,12 +60,12 @@ exports[`Checkbox should render a checkbox partially checked 1`] = `
   <input
     checked={false}
     disabled={false}
-    id="toggleButton3"
+    id="checkbox3"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    htmlFor="toggleButton3"
+    htmlFor="checkbox3"
     onClick={undefined}
   >
     <span
@@ -141,12 +141,12 @@ exports[`Checkbox should render a checkbox with label 1`] = `
   <input
     checked={true}
     disabled={false}
-    id="toggleButton2"
+    id="checkbox2"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    htmlFor="toggleButton2"
+    htmlFor="checkbox2"
     onClick={undefined}
   >
     <span
@@ -193,12 +193,12 @@ exports[`Checkbox should render shallow component ok 1`] = `
   <input
     checked={true}
     disabled={false}
-    id="toggleButton1"
+    id="checkbox1"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    htmlFor="toggleButton1"
+    htmlFor="checkbox1"
     onClick={undefined}
   />
 </div>

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -69,7 +69,7 @@ export default class Checkbox extends PureComponent<TProps> {
       ...otherProps
     } = this.props;
 
-    const id = uniqueId('toggleButton');
+    const id = uniqueId('checkbox');
 
     const _classNames = cx({
       [coreStyles['ui-checkbox']]: true,

--- a/src/components/radio/__tests__/__snapshots__/radio.test.js.snap
+++ b/src/components/radio/__tests__/__snapshots__/radio.test.js.snap
@@ -31,12 +31,12 @@ exports[`Radio should render shallow component ok 1`] = `
   <input
     checked={true}
     disabled={undefined}
-    id="toggleButton1"
+    id="radio1"
     onChange={[Function]}
     type="radio"
   />
   <label
-    htmlFor="toggleButton1"
+    htmlFor="radio1"
     onClick={undefined}
   />
 </div>

--- a/src/components/radio/radio.js
+++ b/src/components/radio/radio.js
@@ -36,7 +36,7 @@ export default function Radio(props: RadioProps) {
     ...otherProps
   } = props;
 
-  const id = uniqueId('toggleButton');
+  const id = uniqueId('radio');
 
   const _classNames = cx({
     [coreStyles['ui-radio']]: true,


### PR DESCRIPTION
The Radio and Checkbox components are currently generating random ids using a `toggleButton` prefix. 