### PR TITLE
Remove default appearance from inputs

### DIFF
--- a/src/components/input/input.core.css
+++ b/src/components/input/input.core.css
@@ -7,6 +7,7 @@
   border-radius: 4px;
   border: 1px solid var(--grey400);
   padding: 4px 8px 4px 16px;
+  -webkit-appearance: none;
 
   &:focus {
     outline: 0;


### PR DESCRIPTION
Inputs on iOS get an additional inner shadow. This PR removes the default treatment.