### PR TITLE
UI Validation and Select Fixes

### DIFF
--- a/src/components/input/input.core.css
+++ b/src/components/input/input.core.css
@@ -74,10 +74,12 @@
   }
 }
 
+.ui-input:valid,
 .ui-input--valid {
   border-color: var(--green500) !important;
 }
 
+.ui-input:invalid,
 .ui-input--invalid {
   border-color: var(--pink500) !important;
 }

--- a/src/components/select/__examples__/select.examples.js
+++ b/src/components/select/__examples__/select.examples.js
@@ -52,6 +52,15 @@ export const examples = [
     title: 'Select',
     description: 'A standard Select',
     render: () => <SelectDemo />,
+    html: () => (
+      <select className="ui-select">
+        {COUNTRIES.map(country => (
+          <option key={country.name} value={country.name}>
+            {country.name}
+          </option>
+        ))}
+      </select>
+    ),
   },
   {
     title: 'Disabled select',
@@ -66,6 +75,15 @@ export const examples = [
           <Option key={country.name}>{country.name}</Option>
         ))}
       </Select>
+    ),
+    html: () => (
+      <select className="ui-select" disabled={true}>
+        {COUNTRIES.map(country => (
+          <option key={country.name} value={country.name}>
+            {country.name}
+          </option>
+        ))}
+      </select>
     ),
   },
   {

--- a/src/components/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/components/select/__tests__/__snapshots__/select.test.js.snap
@@ -23,28 +23,6 @@ exports[`Select should render a disabled select 1`] = `
     >
       Select…
     </span>
-    <div
-      className="ui-select__chevron"
-    >
-      <i
-        className="e2anemp0 css-1kj0oyh"
-        color="grey500"
-        onClick={undefined}
-        size={24}
-        style={Object {}}
-        title={undefined}
-      >
-        <svg
-          aria-hidden="true"
-          height={24}
-          width={24}
-        >
-          <use
-            xlinkHref="#chevron_right"
-          />
-        </svg>
-      </i>
-    </div>
   </div>
   <div
     className="ui-select__option-group"
@@ -118,28 +96,6 @@ exports[`Select should render a readonly select 1`] = `
     >
       Select…
     </span>
-    <div
-      className="ui-select__chevron"
-    >
-      <i
-        className="e2anemp0 css-1kj0oyh"
-        color="grey500"
-        onClick={undefined}
-        size={24}
-        style={Object {}}
-        title={undefined}
-      >
-        <svg
-          aria-hidden="true"
-          height={24}
-          width={24}
-        >
-          <use
-            xlinkHref="#chevron_right"
-          />
-        </svg>
-      </i>
-    </div>
   </div>
   <div
     className="ui-select__option-group"
@@ -213,28 +169,6 @@ exports[`Select should render shallow component ok 1`] = `
     >
       Select…
     </span>
-    <div
-      className="ui-select__chevron"
-    >
-      <i
-        className="e2anemp0 css-84m9du"
-        color="navy700"
-        onClick={undefined}
-        size={24}
-        style={Object {}}
-        title={undefined}
-      >
-        <svg
-          aria-hidden="true"
-          height={24}
-          width={24}
-        >
-          <use
-            xlinkHref="#chevron_right"
-          />
-        </svg>
-      </i>
-    </div>
   </div>
   <div
     className="ui-select__option-group"

--- a/src/components/select/select.core.css
+++ b/src/components/select/select.core.css
@@ -18,6 +18,10 @@
     outline: 0;
     border: 1px solid var(--blue500);
   }
+
+  &:invalid {
+    border: 1px solid var(--pink500);
+  }
 }
 
 .ui-select:disabled,

--- a/src/components/select/select.core.css
+++ b/src/components/select/select.core.css
@@ -5,10 +5,16 @@
   border: 1px solid var(--grey400);
   border-radius: 4px;
   background-color: var(--white);
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMS40MS41OUwwIDJsNiA2IDYtNkwxMC41OS41OSA2IDUuMTd6IiBmaWxsPSIjMzc0NTYxIiBmaWxsLXJ1bGU9Im5vbnplcm8iLz48L3N2Zz4=);
+  background-repeat: no-repeat;
+  background-position: calc(100% - 24px) 50%;
   height: 40px;
   text-align: left;
   cursor: pointer;
   font-size: 14px;
+  appearance: none;
+  padding: 2px 16px;
+  color: var(--navy700);
 
   &:hover {
     border: 1px solid var(--grey500);
@@ -27,6 +33,7 @@
 .ui-select:disabled,
 .ui-select--disabled {
   background-color: var(--navy300);
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMS40MS41OUwwIDJsNiA2IDYtNkwxMC41OS41OSA2IDUuMTd6IiBmaWxsPSIjQjBCQUMzIiBmaWxsLXJ1bGU9Im5vbnplcm8iLz48L3N2Zz4=);
   border: 1px solid var(--grey400);
   cursor: not-allowed;
   color: var(--navy600);

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -168,17 +168,6 @@ export default class Select extends PureComponent<TProps, TState> {
               </Icon>
             </div>
           )}
-          {(!readonly || !disabled) &&
-          (!selection || !nullable) && (
-            <div className={reactStyles['ui-select__chevron']}>
-              <Icon
-                color={readonly || disabled ? 'grey500' : 'navy700'}
-                size={24}
-              >
-                chevron_right
-              </Icon>
-            </div>
-          )}
         </div>
         <div
           className={reactStyles['ui-select__option-group']}

--- a/src/components/select/select.react.css
+++ b/src/components/select/select.react.css
@@ -2,8 +2,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 2px 10px;
-  height: 40px;
+  padding: 0;
+  height: 34px;
 }
 
 .ui-select__chevron {


### PR DESCRIPTION
- `inputs` and `selects` are now displayed as invalid via the `:invalid` pseudoclass. Required for HTML5 validation in Identity. The classes (`ui-input--invalid`) are still available.

- The native and React dropdowns now look more alike.

Native Select:
![image](https://user-images.githubusercontent.com/3749759/45491810-8a505a80-b762-11e8-9442-cf291559fec1.png)
