### PR TITLE
Explicitly set line height on inputs

### DIFF
--- a/src/components/input/input.core.css
+++ b/src/components/input/input.core.css
@@ -7,6 +7,7 @@
   border-radius: 4px;
   border: 1px solid var(--grey400);
   padding: 4px 8px 4px 16px;
+  line-height: 1.6em;
   -webkit-appearance: none;
 
   &:focus {


### PR DESCRIPTION
Placeholder text in the input on mobile isn't vertically centered.

Setting an oversized line-height fixes this.