### PR TITLE
Bump lodash version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "dev": true,
       "requires": {
         "@babel/types": "7.0.0-beta.32",
-        "lodash": "4.17.2"
+        "lodash": "4.17.5"
       }
     },
     "@babel/highlight": {
@@ -78,7 +78,7 @@
       "dev": true,
       "requires": {
         "esutils": "2.0.2",
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "to-fast-properties": "2.0.0"
       },
       "dependencies": {
@@ -878,7 +878,7 @@
         "convert-source-map": "1.5.1",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "output-file-sync": "1.1.2",
         "path-is-absolute": "1.0.1",
         "slash": "1.0.0",
@@ -947,7 +947,7 @@
         "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -1399,7 +1399,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "lodash": "4.17.2"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "glob": {
@@ -1482,7 +1482,7 @@
       "integrity": "sha1-UVu/qZaJOYEULZCx+bFjXeKZUQk=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.2"
+        "lodash": "4.17.5"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -2705,7 +2705,7 @@
         "dom-serializer": "0.1.0",
         "entities": "1.1.1",
         "htmlparser2": "3.9.2",
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "parse5": "3.0.3"
       },
       "dependencies": {
@@ -4391,7 +4391,7 @@
         "js-yaml": "3.7.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
@@ -4451,7 +4451,7 @@
             "cli-cursor": "1.0.2",
             "cli-width": "2.2.0",
             "figures": "1.7.0",
-            "lodash": "4.17.2",
+            "lodash": "4.17.5",
             "readline2": "1.0.1",
             "run-async": "0.1.0",
             "rx-lite": "3.1.2",
@@ -4548,7 +4548,7 @@
       "integrity": "sha1-u+4YXe35fl9j7Jdc3N3Rmb0qJQE=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.2"
+        "lodash": "4.17.5"
       }
     },
     "eslint-plugin-import": {
@@ -4871,7 +4871,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.2"
+            "lodash": "4.17.5"
           }
         },
         "source-list-map": {
@@ -7565,7 +7565,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rxjs": "5.5.3",
@@ -8261,7 +8261,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.2"
+            "lodash": "4.17.5"
           }
         },
         "fileset": {
@@ -9670,7 +9670,7 @@
             "cli-width": "2.2.0",
             "external-editor": "2.2.0",
             "figures": "2.0.0",
-            "lodash": "4.17.2",
+            "lodash": "4.17.5",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
             "rx-lite": "4.0.8",
@@ -9855,9 +9855,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-      "integrity": "sha1-NKMFW6vgTOQkZ7YH1wAHLH/2v0I=",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
       "dev": true
     },
     "lodash._arraymap": {
@@ -14415,7 +14415,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "log-symbols": "1.0.2",
         "postcss": "5.2.18"
       }
@@ -14970,7 +14970,7 @@
       "integrity": "sha1-eke6Qze+iSWpagJObVjUMwlqMjM=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "mousetrap": "1.6.1"
       }
     },
@@ -15469,7 +15469,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.2"
+        "lodash": "4.17.5"
       }
     },
     "request-promise-native": {
@@ -16789,7 +16789,7 @@
         "ajv": "4.11.8",
         "ajv-keywords": "1.5.1",
         "chalk": "1.1.3",
-        "lodash": "4.17.2",
+        "lodash": "4.17.5",
         "slice-ansi": "0.0.4",
         "string-width": "2.1.1"
       },
@@ -17840,7 +17840,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.2"
+            "lodash": "4.17.5"
           }
         }
       }
@@ -17896,7 +17896,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.2"
+            "lodash": "4.17.5"
           }
         },
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest": "22.4.1",
     "jest-emotion": "^9.0.0",
     "lint-staged": "3.4.2",
-    "lodash": "4.17.2",
+    "lodash": "4.17.5",
     "np": "^3.0.4",
     "postcss-cli": "3.2.0",
     "postcss-css-variables": "0.7.0",


### PR DESCRIPTION
Updates the version of lodash as the version we are currently using has a 'potential security vulnerability'.

![image](https://user-images.githubusercontent.com/3749759/45965300-06c72100-c020-11e8-919d-10be4cbef695.png)
