### PR TITLE
Fix styling of link buttons

### DIFF
--- a/src/components/button/__examples__/button.examples.js
+++ b/src/components/button/__examples__/button.examples.js
@@ -209,6 +209,19 @@ export const examples = [
     ),
   },
   {
+    title: 'Button Link',
+    render: () => (
+      <Button component="a" variant="tertiary">
+        Link button
+      </Button>
+    ),
+    html: () => (
+      <a href="#" className="ui-btn ui-btn--tertiary ui-btn--medium">
+        Link button
+      </a>
+    ),
+  },
+  {
     title: 'Themed button',
     description:
       'When used in the platform, primary buttons can inherit their colors from the theme (React only)',

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -7,10 +7,16 @@
   font-weight: 500;
   display: flex;
   align-items: center;
+  justify-content: center;
   vertical-align: middle;
   transition: background 0.3s ease-out, color 0.2s ease-out;
   background-color: var(--white);
   color: var(--navy700);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: none;
+  }
 
   &:focus {
     outline: 0;


### PR DESCRIPTION
Links that are styled as buttons are also inheriting the new global link styling (underlines). This PR fixes this.