### PR TITLE
Allow border-radius of paper to be overridden

### DIFF
--- a/src/components/paper/__examples__/paper.examples.js
+++ b/src/components/paper/__examples__/paper.examples.js
@@ -29,4 +29,12 @@ export const examples = [
       </span>
     ),
   },
+  {
+    title: 'With no border-radius',
+    render: () => (
+      <Paper padding={48} rounded={false}>
+        this is some demo content
+      </Paper>
+    ),
+  },
 ];

--- a/src/components/paper/paper.css
+++ b/src/components/paper/paper.css
@@ -69,6 +69,10 @@
   border: 0;
 }
 
+.ui-paper--not-rounded {
+  border-radius: 0;
+}
+
 .ui-paper--interactive {
   cursor: pointer;
 }

--- a/src/components/paper/paper.js
+++ b/src/components/paper/paper.js
@@ -30,6 +30,7 @@ type Props = {
 export default function Paper(props: Props) {
   const {
     border = true,
+    rounded = true,
     children,
     elevation = 1,
     hoverElevation = 1,
@@ -52,14 +53,14 @@ export default function Paper(props: Props) {
       [coreStyles['ui-paper--opaque']]: opaque,
       [coreStyles['ui-paper--wireframe']]: wireframe,
       [coreStyles['ui-paper--no-border']]: !border,
-      [coreStyles['ui-paper--interactive']]: !!onClick,
+      [coreStyles['ui-paper--not-rounded']]: !rounded,
+      [coreStyles['ui-paper--interactive']]: Boolean(onClick),
     },
     className
   );
 
   return (
     <UIBase
-      interactive={!!onClick}
       onClick={onClick}
       className={_classNames}
       component={component}


### PR DESCRIPTION
Re-implements the `rounded` prop on Paper to disable the border radius.

This is by default set to true.

```
<Paper rounded={false} />
```