### PR TITLE
Add flare button to styleguide

### DIFF
--- a/src/components/button/__examples__/button.examples.js
+++ b/src/components/button/__examples__/button.examples.js
@@ -80,6 +80,16 @@ export const examples = [
     ),
   },
   {
+    title: 'Flare Button',
+    description: 'Used for marketing, and flows in to the app',
+    render: () => <Button variant="flare">Create Account</Button>,
+    html: () => (
+      <button className="ui-btn ui-btn--flare ui-btn--medium">
+        Create Account
+      </button>
+    ),
+  },
+  {
     title: 'Delete Button',
     description: 'An action button for deleting/removing.',
     render: () => <Button variant="delete">Remove freelancer</Button>,

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -170,6 +170,27 @@
   }
 }
 
+.ui-btn--flare {
+  background: var(--gradient-pink);
+  color: var(--white);
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: 1.3rem;
+  transition: filter 0.2s ease-out;
+
+  &:hover {
+    filter: brightness(110%);
+  }
+
+  &:active {
+    filter: brightness(95%);
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 3px var(--pink200);
+  }
+}
+
 .ui-btn--delete {
   border-style: solid;
   border-width: 1px;
@@ -242,9 +263,10 @@
   */
 .ui-btn--disabled,
 .ui-btn:disabled {
-  background-color: var(--grey100);
+  background: var(--grey100);
   color: var(--grey500);
   cursor: default;
+  filter: none;
 }
 
 .ui-btn--loading {

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -38,7 +38,13 @@ type TProps = {
   /** The visual size */
   size?: 'small' | 'medium' | 'large' | 'extra-large',
   /** The visual theme */
-  variant?: 'primary' | 'secondary' | 'tertiary' | 'delete' | 'action',
+  variant?:
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'delete'
+    | 'action'
+    | 'flare',
   /** Ignore - Set by ButtonGroup */
   grouped?: boolean,
   /** Ignore - Set by ButtonGroup */


### PR DESCRIPTION
The flare button already exists in Identity and Klassic, so it makes sense to bring it in to UI.

Most browsers don't support animating between two css gradients, and so the lightening and darkening that happen on hover/active are achieved through adjusting the `brightness` by way of a filter.

![image](https://user-images.githubusercontent.com/3749759/51250502-775aca80-198e-11e9-9ae8-ec025e42143a.png)

