### PR TITLE
Use package-lock.json for Circle cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,7 @@ defaultRestoreCachedModules: &defaultRestoreCachedModules
   restore_cache:
     name: Restore cached node_modules
     keys:
-      - v1-dependencies-{{ checksum "package.json" }}
-      # fallback to using the latest cache if no exact match is found
-      - v1-dependencies-
+      - v1-dependencies-{{ checksum "package-lock.json" }}
 
 defaultNpmInstall: &defaultNpmInstall
   run:
@@ -24,7 +22,7 @@ defaultCacheModules: &defaultCacheModules
     name: Save node_modules cache
     paths:
       - node_modules
-    key: v1-dependencies-{{ checksum "package.json" }}
+    key: v1-dependencies-{{ checksum "package-lock.json" }}
 
 jobs:
   lint:


### PR DESCRIPTION
This makes builds reproducible, since `npm ci` uses `package-lock.json`.

We remove the use of a partially matched cache, as our detection of
`node_modules` would make circle skip the `npm ci` step, which would
update the cache.