### PR TITLE
Lowercase flare button text

### DIFF
--- a/src/components/button/__examples__/button.examples.js
+++ b/src/components/button/__examples__/button.examples.js
@@ -217,7 +217,7 @@ export const examples = [
       </ButtonGroup>
     ),
     html: () => (
-      <div className="ui-button-group">
+      <div className="ui-btn-group">
         <button className="ui-btn ui-btn--tertiary ui-btn--small">Small</button>
         <button className="ui-btn ui-btn--tertiary ui-btn--medium">
           medium

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -173,9 +173,6 @@
 .ui-btn--flare {
   background: var(--gradient-pink);
   color: var(--white);
-  text-transform: uppercase;
-  font-weight: 700;
-  font-size: 1.3rem;
   transition: filter 0.2s ease-out;
 
   &:hover {


### PR DESCRIPTION
Removes the one-off styling for the Flare button style, to bring it inline with the other button styles.

Now looks like:
![image](https://user-images.githubusercontent.com/3749759/54427145-8c937180-4711-11e9-94ab-1a6bd1d3594f.png)
