### PR TITLE
Change GroupedAvatar css to be self-contained

### DIFF
--- a/src/components/avatar-group/__examples__/avatar-group.examples.js
+++ b/src/components/avatar-group/__examples__/avatar-group.examples.js
@@ -17,7 +17,7 @@ export const examples = [
     html: () => (
       <div className="ui-avatar-group">
         <span
-          className="ui-avatar ui-avatar--medium ui-avatar--fallback-orange"
+          className="ui-avatar ui-avatar--medium ui-avatar--grouped ui-avatar--fallback-orange"
           data-fallback-initials="AC"
           aria-label="Mary Freelancer"
           role="img"
@@ -25,7 +25,7 @@ export const examples = [
           <span className="ui-avatar__avatar" />
         </span>
         <span
-          className="ui-avatar ui-avatar--medium ui-avatar--fallback-pink"
+          className="ui-avatar ui-avatar--medium ui-avatar--grouped ui-avatar--fallback-pink"
           data-fallback-initials="PJ"
           aria-label="Mary Freelancer"
           role="img"
@@ -33,7 +33,7 @@ export const examples = [
           <span className="ui-avatar__avatar" />
         </span>
         <span
-          className="ui-avatar ui-avatar--medium ui-avatar--fallback-green"
+          className="ui-avatar ui-avatar--medium ui-avatar--grouped ui-avatar--fallback-green"
           data-fallback-initials="CL"
           aria-label="Mary Freelancer"
           role="img"
@@ -78,7 +78,7 @@ export const examples = [
     html: () => (
       <div className="ui-avatar-group">
         <span
-          className="ui-avatar ui-avatar--medium ui-avatar--fallback-orange"
+          className="ui-avatar ui-avatar--medium ui-avatar--grouped ui-avatar--fallback-orange"
           data-fallback-initials="AC"
           aria-label="Mary Freelancer"
           role="img"
@@ -86,7 +86,7 @@ export const examples = [
           <span className="ui-avatar__avatar" />
         </span>
         <span
-          className="ui-avatar ui-avatar--medium ui-avatar--fallback-pink"
+          className="ui-avatar ui-avatar--medium ui-avatar--grouped ui-avatar--fallback-pink"
           data-fallback-initials="PJ"
           aria-label="Mary Freelancer"
           role="img"
@@ -94,7 +94,7 @@ export const examples = [
           <span className="ui-avatar__avatar" />
         </span>
         <span
-          className="ui-avatar ui-avatar--medium ui-avatar--fallback-green"
+          className="ui-avatar ui-avatar--medium ui-avatar--grouped ui-avatar--fallback-green"
           data-fallback-initials="CL"
           aria-label="Mary Freelancer"
           role="img"
@@ -102,7 +102,7 @@ export const examples = [
           <span className="ui-avatar__avatar" />
         </span>
         <span
-          className="ui-avatar ui-avatar--medium ui-avatar--fallback-blue"
+          className="ui-avatar ui-avatar--medium ui-avatar--grouped ui-avatar--fallback-blue"
           data-fallback-initials="PJ"
           aria-label="Mary Freelancer"
           role="img"
@@ -110,7 +110,7 @@ export const examples = [
           <span className="ui-avatar__avatar" />
         </span>
         <span
-          className="ui-avatar ui-avatar--medium ui-avatar--fallback-orange"
+          className="ui-avatar ui-avatar--medium ui-avatar--grouped ui-avatar--fallback-orange"
           data-fallback-initials="MF"
           aria-label="Mary Freelancer"
           role="img"

--- a/src/components/avatar-group/avatar-group.css
+++ b/src/components/avatar-group/avatar-group.css
@@ -10,44 +10,6 @@
  * that when an avatar group is aligned next to a non-grouped
  * avatar, the sizes will still remain consistent
  */
-.ui-avatar-group .ui-avatar {
-  margin-left: -0.45em;
-  box-shadow: 0 0 0 2px var(--white);
-}
-
-.ui-avatar-group .ui-avatar--large,
-.ui-avatar-group .ui-avatar--extra-large {
-  box-shadow: 0 0 0 3px var(--white);
-}
-
-.ui-avatar-group .ui-avatar--large,
-.ui-avatar-group .ui-avatar--extra-large {
-  border: 3px solid var(--white);
-}
-
-.ui-avatar-group .ui-avatar:nth-of-type(1) {
-  z-index: 5;
-}
-
-.ui-avatar-group .ui-avatar:nth-of-type(2) {
-  z-index: 4;
-}
-
-.ui-avatar-group .ui-avatar:nth-of-type(3) {
-  z-index: 3;
-}
-
-.ui-avatar-group .ui-avatar:nth-of-type(4) {
-  z-index: 2;
-}
-
-.ui-avatar-group .ui-avatar:nth-of-type(5) {
-  z-index: 1;
-}
-
-.ui-avatar-group .ui-avatar:first-of-type {
-  margin-left: 0;
-}
 
 .ui-avatar-group__chip {
   background-color: var(--grey100);

--- a/src/components/avatar-group/avatar-group.js
+++ b/src/components/avatar-group/avatar-group.js
@@ -21,7 +21,15 @@ export default function AvatarGroup(props: TProps) {
 
   return (
     <div className={_classNames}>
-      {slicedChildren}
+      {slicedChildren &&
+        React.Children.map(
+          slicedChildren,
+          child =>
+            child && // $FlowFixMe
+            React.cloneElement(child, {
+              isGrouped: true,
+            })
+        )}
       {numberOfChildren > 5 && (
         <span className="ui-avatar--medium ui-avatar-group__chip">
           {numberOfChildren - 5}

--- a/src/components/avatar/avatar.css
+++ b/src/components/avatar/avatar.css
@@ -82,3 +82,42 @@
 .ui-avatar--fallback-navy:after {
   background-color: var(--navy900);
 }
+
+.ui-avatar--grouped {
+  margin-left: -0.45em;
+  box-shadow: 0 0 0 2px var(--white);
+}
+
+.ui-avatar--grouped .ui-avatar--large,
+.ui-avatar--grouped .ui-avatar--extra-large {
+  box-shadow: 0 0 0 3px var(--white);
+}
+
+.ui-avatar--grouped .ui-avatar--large,
+.ui-avatar--grouped .ui-avatar--extra-large {
+  border: 3px solid var(--white);
+}
+
+.ui-avatar--grouped .ui-avatar:nth-of-type(1) {
+  z-index: 5;
+}
+
+.ui-avatar--grouped .ui-avatar:nth-of-type(2) {
+  z-index: 4;
+}
+
+.ui-avatar--grouped .ui-avatar:nth-of-type(3) {
+  z-index: 3;
+}
+
+.ui-avatar--grouped .ui-avatar:nth-of-type(4) {
+  z-index: 2;
+}
+
+.ui-avatar--grouped .ui-avatar:nth-of-type(5) {
+  z-index: 1;
+}
+
+.ui-avatar--grouped .ui-avatar:first-of-type {
+  margin-left: 0;
+}

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -32,6 +32,8 @@ type TProps = {
   resourceHash?: string,
   /** Any classes to pass down */
   className?: string,
+  /** Is the avatar grouped */
+  isGrouped?: boolean,
 };
 
 export default function Avatar(props: TProps) {
@@ -41,6 +43,7 @@ export default function Avatar(props: TProps) {
     className,
     initials,
     resourceHash,
+    isGrouped,
     ...otherProps
   } = props;
 
@@ -53,6 +56,7 @@ export default function Avatar(props: TProps) {
       [styles['ui-avatar']]: true,
       [styles[`ui-avatar--${size}`]]: true,
       [styles[`ui-avatar--fallback-${fallbackColor}`]]: true,
+      [styles[`ui-avatar--grouped`]]: isGrouped,
     },
     className
   );


### PR DESCRIPTION
The avatar grouped classes were breaking due to them not complying with the CSS Modules standard of total encapsulation. The AvatarGroup component was trying to reference the Avatar class.

This PR moves the grouping classes to the AvatarGroup component.