### PR TITLE
Fix grouped Avatar stacking order

### DIFF
--- a/src/components/avatar/avatar.css
+++ b/src/components/avatar/avatar.css
@@ -98,26 +98,26 @@
   border: 3px solid var(--white);
 }
 
-.ui-avatar--grouped .ui-avatar:nth-of-type(1) {
+.ui-avatar--grouped:nth-of-type(1) {
   z-index: 5;
 }
 
-.ui-avatar--grouped .ui-avatar:nth-of-type(2) {
+.ui-avatar--grouped:nth-of-type(2) {
   z-index: 4;
 }
 
-.ui-avatar--grouped .ui-avatar:nth-of-type(3) {
+.ui-avatar--grouped:nth-of-type(3) {
   z-index: 3;
 }
 
-.ui-avatar--grouped .ui-avatar:nth-of-type(4) {
+.ui-avatar--grouped:nth-of-type(4) {
   z-index: 2;
 }
 
-.ui-avatar--grouped .ui-avatar:nth-of-type(5) {
+.ui-avatar--grouped:nth-of-type(5) {
   z-index: 1;
 }
 
-.ui-avatar--grouped .ui-avatar:first-of-type {
+.ui-avatar--grouped:first-of-type {
   margin-left: 0;
 }


### PR DESCRIPTION
The `z-index` was not being set on grouped Avatar components, which resulted in the stacking order being incorrect.

**Before:**

![image](https://user-images.githubusercontent.com/3749759/55161391-561c1480-515d-11e9-82b4-cab1038324c9.png)

**After:**
![image](https://user-images.githubusercontent.com/3749759/55161405-5ddbb900-515d-11e9-9778-7a45b612b56f.png)

