### PR TITLE
Add field-row classes

### DIFF
--- a/src/components/field-row/__tests__/__snapshots__/field-row.test.js.snap
+++ b/src/components/field-row/__tests__/__snapshots__/field-row.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Input should render shallow component ok 1`] = `
 <div
-  className="e1q9f2xp0 css-10rqj9x"
+  className="ui-field-row e1q9f2xp6 css-150a2en"
   style={Object {}}
 >
   <div

--- a/src/components/field-row/field-row.css
+++ b/src/components/field-row/field-row.css
@@ -1,0 +1,5 @@
+.ui-field-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: top;
+}

--- a/src/components/field-row/field-row.js
+++ b/src/components/field-row/field-row.js
@@ -1,8 +1,11 @@
 /* @flow */
 import * as React from 'react';
+import cx from 'classnames';
 import {pickStyles} from '../../utils/style';
 
-import {Box} from '../layout';
+import {UIBase} from '../layout';
+
+import styles from './field-row.css';
 
 export const DEFAULT_SPACING = 20;
 
@@ -22,11 +25,16 @@ type TProps = {
 export default function FieldRow(props: TProps) {
   const {children, gutter = DEFAULT_SPACING, className, ...otherProps} = props;
 
+  const _classNames = cx(
+    {
+      [styles['ui-field-row']]: true,
+    },
+    className
+  );
+
   return (
-    <Box
-      className={className}
-      flexDirection="row"
-      alignItems="top"
+    <UIBase
+      className={_classNames}
       marginLeft={-gutter}
       marginTop={DEFAULT_SPACING}
       {...pickStyles(otherProps)}
@@ -40,6 +48,6 @@ export default function FieldRow(props: TProps) {
             })
           : child
       )}
-    </Box>
+    </UIBase>
   );
 }


### PR DESCRIPTION
There are currently no classes for the FieldRow component. This PR removes the implicit styles that would be added to the React component from `Box`, and hard-codes them in to `ui-field-row` so that they can be used in the non-react version of UI