### PR TITLE
SeamlessButton forced active state

### DIFF
--- a/src/components/seamless-button/__examples__/seamless-button.examples.js
+++ b/src/components/seamless-button/__examples__/seamless-button.examples.js
@@ -14,4 +14,19 @@ export const examples = [
       </button>
     ),
   },
+  {
+    title: 'Seamless Button with forced active state',
+    description:
+      'This can be useful when used with a contextual menu and the menu is open',
+    render: () => (
+      <SeamlessButton size="medium" icon="more_vert" active={true} />
+    ),
+    html: () => (
+      <button className="ui-seamless-button ui-seamless-button--medium ui-seamless-button--active">
+        <svg width="20" height="20" aria-hidden="true">
+          <use xlinkHref="#more_vert" />
+        </svg>
+      </button>
+    ),
+  },
 ];

--- a/src/components/seamless-button/seamless-button.css
+++ b/src/components/seamless-button/seamless-button.css
@@ -6,7 +6,8 @@
   cursor: pointer;
 }
 
-.ui-seamless-button:hover {
+.ui-seamless-button:hover,
+.ui-seamless-button--active {
   background-color: var(--grey100);
 }
 

--- a/src/components/seamless-button/seamless-button.css
+++ b/src/components/seamless-button/seamless-button.css
@@ -1,4 +1,7 @@
 .ui-seamless-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: none;
   border: 0;
   padding: 0;

--- a/src/components/seamless-button/seamless-button.react.js
+++ b/src/components/seamless-button/seamless-button.react.js
@@ -8,11 +8,18 @@ import Icon from '../icon';
 import styles from './seamless-button.css';
 
 type TProps = {
+  /** An onclick event to call */
   onClick?: () => void,
+  /** A name to pass down to the DOM button */
   name?: string,
+  /** Any classes to pass down */
   className?: string,
+  /** The physical size of the button */
   size?: 'small' | 'medium' | 'large',
+  /** An icon to display as a child */
   icon?: string,
+  /** Forces the button to be in active state. */
+  active?: boolean,
 };
 /**
  * A thing which doesn’t look like a button but makes things happen when you
@@ -25,6 +32,7 @@ export default function SeamlessButton(props: TProps) {
     size = 'medium',
     className,
     icon = 'add',
+    active,
     ...otherProps
   } = props;
 
@@ -32,6 +40,7 @@ export default function SeamlessButton(props: TProps) {
     {
       [styles['ui-seamless-button']]: true,
       [styles[`ui-seamless-button--${size}`]]: true,
+      [styles[`ui-seamless-button--active`]]: Boolean(active),
     },
     className
   );


### PR DESCRIPTION
This provides a way to force the SeamlessButton to show as 'active' even when not. This can be useful in a number of scenarios including when using it as a trigger for a contextual menu. When the contextual menu is open, the button can be forced to be displayed as active.

- Also added a few comments to the types to bolster the docs