### PR TITLE
Use 'auto', not 'scroll'

### DIFF
--- a/src/styles/kalo-ui-base.css
+++ b/src/styles/kalo-ui-base.css
@@ -21,7 +21,7 @@ body {
 }
 
 html {
-  overflow-y: scroll;
+  overflow-y: auto;
   font-size: 62.5%;
 
   /**


### PR DESCRIPTION
Replace 'scroll' with 'auto'.

There's a PR to remove the `fullscreen` component in the frontend repo but once this hoc is no longer present in the stack the default value of 'scroll' used against `html` is causing a scrollbar to show.

I'd like to change this value to 'auto'. I can't see any reason to have it forcing the scroll bar at this level but if there is, please shout!