### PR TITLE
Remove grey background from neutral lozenge

### DIFF
--- a/src/components/lozenge/lozenge.css
+++ b/src/components/lozenge/lozenge.css
@@ -38,7 +38,6 @@
 }
 
 .ui-lozenge--variant-grey {
-  background-color: var(--grey000);
   color: var(--grey700);
   border: 1px solid var(--grey200);
 }


### PR DESCRIPTION
They currently look as if they are in a 'disabled' state, rather than just being neutral.
