### PR TITLE
fixed export of inline alert

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -61,6 +61,7 @@ export {
  * Other
  */
 export {default as Alert, AlertPopover} from './alert';
+export {default as InlineAlert} from './inline-alert';
 export {default as Icon} from './icon';
 export {default as IconSymbols} from './icon-symbols';
 export {default as LoadingSpinner} from './loading-spinner';


### PR DESCRIPTION
The `InlineAlert` component https://kalo.design/components/inline-alert/ wasn't exposed in the node module.