### PR TITLE
added tooltip-box component

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -77,6 +77,7 @@ export {default as Modal} from './modal';
 export {Tab, Tabs} from './tabs';
 export {default as FeatureCalloutCard} from './feature-callout-card';
 export {default as Callout} from './callout';
+export {default as TooltipBox} from './tooltip-box';
 
 /**
  * Theme

--- a/src/components/tooltip-box/README.md
+++ b/src/components/tooltip-box/README.md
@@ -1,0 +1,3 @@
+# TooltipBox
+
+It creates a tooltip-ready element

--- a/src/components/tooltip-box/__examples__/tooltip-box.examples.js
+++ b/src/components/tooltip-box/__examples__/tooltip-box.examples.js
@@ -15,4 +15,20 @@ export const examples = [
       </div>
     ),
   },
+  {
+    title: 'TooltipBox - show right',
+    render: () => (
+      <TooltipBox text="Hello! I am a tooltip" show="right">
+        Hover me :)
+      </TooltipBox>
+    ),
+    html: () => (
+      <div className="tooltip-container">
+        Hover me :)
+        <div className="tooltip-bubble tooltip-bubble--right">
+          Hello! I am a tooltip
+        </div>
+      </div>
+    ),
+  },
 ];

--- a/src/components/tooltip-box/__examples__/tooltip-box.examples.js
+++ b/src/components/tooltip-box/__examples__/tooltip-box.examples.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import TooltipBox from '..';
+
+export const examples = [
+  {
+    title: 'TooltipBox',
+    render: () => (
+      <TooltipBox text="Hello! I am a tooltip">Hover me :)</TooltipBox>
+    ),
+    html: () => (
+      <div className="tooltip-container">
+        Hover me :)
+        <div className="tooltip-bubble">Hello! I am a tooltip</div>
+      </div>
+    ),
+  },
+];

--- a/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
+++ b/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TooltipBox should render properly - show right 1`] = `
+<div
+  className="tooltip-container"
+>
+  Hover me :)
+  <div
+    className="tooltip-bubble tooltip-bubble--right"
+  >
+    Hello! I am a tooltip
+  </div>
+</div>
+`;
+
 exports[`TooltipBox should render properly 1`] = `
 <div
   className="tooltip-container"

--- a/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
+++ b/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TooltipBox should render properly 1`] = `
+<div
+  className="tooltip-container"
+>
+  Hover me :)
+  <div
+    className="tooltip-bubble"
+  >
+    Hello! I am a tooltip
+  </div>
+</div>
+`;

--- a/src/components/tooltip-box/__tests__/tooltip-box.test.js
+++ b/src/components/tooltip-box/__tests__/tooltip-box.test.js
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import TooltipBox from '../tooltip-box.react';
+
+describe('TooltipBox', () => {
+  test('should render properly', () => {
+    const wrapper = renderer
+      .create(<TooltipBox text="Hello! I am a tooltip">Hover me :)</TooltipBox>)
+      .toJSON();
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/tooltip-box/__tests__/tooltip-box.test.js
+++ b/src/components/tooltip-box/__tests__/tooltip-box.test.js
@@ -9,7 +9,17 @@ describe('TooltipBox', () => {
     const wrapper = renderer
       .create(<TooltipBox text="Hello! I am a tooltip">Hover me :)</TooltipBox>)
       .toJSON();
+    expect(wrapper).toMatchSnapshot();
+  });
 
+  test('should render properly - show right', () => {
+    const wrapper = renderer
+      .create(
+        <TooltipBox text="Hello! I am a tooltip" show="right">
+          Hover me :)
+        </TooltipBox>
+      )
+      .toJSON();
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/tooltip-box/index.js
+++ b/src/components/tooltip-box/index.js
@@ -1,0 +1,1 @@
+export {default} from './tooltip-box.react';

--- a/src/components/tooltip-box/tooltip-box.css
+++ b/src/components/tooltip-box/tooltip-box.css
@@ -1,0 +1,44 @@
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip-bubble {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  border-radius: 4px;
+  background: var(--navy900);
+  transform: translate3d(-50%, 100%, 0);
+  margin-left: 50%;
+  font-size: 14px;
+  color: var(--white);
+  text-align: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 200ms cubic-bezier(0, 1, 1, 1),
+    transform 200ms cubic-bezier(0, 1, 1, 1), visibility 200ms step-start;
+  max-width: 260px;
+  min-width: 200px;
+  padding: 10px 20px;
+
+  &:before {
+    position: absolute;
+    top: 0px;
+    left: 0;
+    margin-left: 50%;
+    display: block;
+    content: '';
+    height: 0;
+    border: transparent solid;
+    border-bottom-color: var(--navy900);
+    transform: translate3d(-50%, -100%, 0);
+    border-width: 0 6px 6px 6px;
+  }
+}
+
+.tooltip-container:hover .tooltip-bubble {
+  visibility: visible;
+  opacity: 1;
+  transform: translate3d(-50%, calc(100% + 8px), 0);
+}

--- a/src/components/tooltip-box/tooltip-box.css
+++ b/src/components/tooltip-box/tooltip-box.css
@@ -5,12 +5,11 @@
 
 .tooltip-bubble {
   position: absolute;
-  left: 0;
   bottom: 0;
+  left: 50%;
+  transform: translate3d(-50%, 100%, 0);
   border-radius: 4px;
   background: var(--navy900);
-  transform: translate3d(-50%, 100%, 0);
-  margin-left: 50%;
   font-size: 14px;
   color: var(--white);
   text-align: center;
@@ -24,16 +23,15 @@
 
   &:before {
     position: absolute;
-    top: 0px;
-    left: 0;
-    margin-left: 50%;
     display: block;
     content: '';
     height: 0;
     border: transparent solid;
-    border-bottom-color: var(--navy900);
-    transform: translate3d(-50%, -100%, 0);
     border-width: 0 6px 6px 6px;
+    border-bottom-color: var(--navy900);
+    top: 0;
+    left: 50%;
+    transform: translate3d(-50%, -100%, 0);
   }
 }
 
@@ -41,4 +39,24 @@
   visibility: visible;
   opacity: 1;
   transform: translate3d(-50%, calc(100% + 8px), 0);
+}
+
+.tooltip-bubble--right {
+  top: 50%;
+  right: 0;
+  bottom: auto;
+  left: auto;
+  transform: translate3d(100%, -50%, 0);
+  &:before {
+    border-width: 6px 6px 6px 0;
+    border-color: transparent var(--navy900) transparent transparent;
+    top: 50%;
+    right: auto;
+    bottom: auto;
+    left: 0;
+    transform: translate3d(-100%, -50%, 0);
+  }
+}
+.tooltip-container:hover .tooltip-bubble--right {
+  transform: translate3d(calc(100% + 8px), -50%, 0);
 }

--- a/src/components/tooltip-box/tooltip-box.react.js
+++ b/src/components/tooltip-box/tooltip-box.react.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import styles from './tooltip-box.css';
+
+const TooltipBox = props => {
+  const {children, text, ...otherProps} = props;
+
+  return (
+    <div className={styles['tooltip-container']} {...otherProps}>
+      {children}
+      <div className={styles['tooltip-bubble']}>{text}</div>
+    </div>
+  );
+};
+
+TooltipBox.propTypes = {
+  /**
+   * The text of the tooltip.
+   */
+  text: PropTypes.string.isRequired,
+  /**
+   * It's the element that triggers the visibility of the tooltip.
+   */
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+export default TooltipBox;

--- a/src/components/tooltip-box/tooltip-box.react.js
+++ b/src/components/tooltip-box/tooltip-box.react.js
@@ -1,15 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 import styles from './tooltip-box.css';
 
+const SUPPORTED_DIRECTIONS = ['right'];
+
 const TooltipBox = props => {
-  const {children, text, ...otherProps} = props;
+  const {children, text, show, className, ...otherProps} = props;
+
+  const classnames = {
+    container: cx(styles['tooltip-container'], className),
+    bubble: cx(styles['tooltip-bubble'], {
+      [styles[`tooltip-bubble--${show}`]]: SUPPORTED_DIRECTIONS.includes(show),
+    }),
+  };
 
   return (
-    <div className={styles['tooltip-container']} {...otherProps}>
+    <div className={classnames.container} {...otherProps}>
       {children}
-      <div className={styles['tooltip-bubble']}>{text}</div>
+      <div className={classnames.bubble}>{text}</div>
     </div>
   );
 };
@@ -23,6 +33,10 @@ TooltipBox.propTypes = {
    * It's the element that triggers the visibility of the tooltip.
    */
   children: PropTypes.node.isRequired,
+  /**
+   * the direction of the tooltip ['right'] (if not indicated pops from the bottom).
+   */
+  show: PropTypes.oneOf(['right']),
   className: PropTypes.string,
 };
 


### PR DESCRIPTION
It adds a tooltip-ready element (react/html-css).

![Screenshot 2019-05-23 at 18 45 08](https://user-images.githubusercontent.com/435399/58274566-0fc4e980-7d8b-11e9-82a5-9b2851c1040e.png)

### How to test it
1. go to `site/`
1. `npm start` to start the style guide
1. go to http://localhost:8000/components/tooltip-box/