### PR TITLE
Use coral color for star-rating component

### DIFF
--- a/src/components/star-rating/__tests__/__snapshots__/star-rating.test.js.snap
+++ b/src/components/star-rating/__tests__/__snapshots__/star-rating.test.js.snap
@@ -1,0 +1,284 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StarRating should render properly 1`] = `
+<div
+  className="root e1krcyn16 css-0"
+  style={Object {}}
+>
+  <div
+    className="star"
+    style={
+      Object {
+        "height": 20,
+        "width": 20,
+      }
+    }
+  >
+    <span
+      className="icon background"
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+    <span
+      className="icon foreground"
+      style={
+        Object {
+          "color": "#f07a7a",
+        }
+      }
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+  </div>
+  <div
+    className="star"
+    style={
+      Object {
+        "height": 20,
+        "width": 20,
+      }
+    }
+  >
+    <span
+      className="icon background"
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+    <span
+      className="icon foreground"
+      style={
+        Object {
+          "color": "#f07a7a",
+        }
+      }
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+  </div>
+  <div
+    className="star"
+    style={
+      Object {
+        "height": 20,
+        "width": 20,
+      }
+    }
+  >
+    <span
+      className="icon background"
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+    <span
+      className="icon foreground"
+      style={
+        Object {
+          "color": "#f07a7a",
+        }
+      }
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+  </div>
+  <div
+    className="star"
+    style={
+      Object {
+        "height": 20,
+        "width": 20,
+      }
+    }
+  >
+    <span
+      className="icon background"
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+    <span
+      className="icon foreground half"
+      style={
+        Object {
+          "color": "#f07a7a",
+        }
+      }
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+  </div>
+  <div
+    className="star"
+    style={
+      Object {
+        "height": 20,
+        "width": 20,
+      }
+    }
+  >
+    <span
+      className="icon background"
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+    <span
+      className="icon foreground"
+      style={
+        Object {
+          "color": false,
+        }
+      }
+    >
+      <i
+        className="ui-icon ui-icon--size-20 fill-currentColor e1krcyn16 css-0"
+        onClick={undefined}
+        style={Object {}}
+        title={undefined}
+      >
+        <svg
+          aria-hidden="true"
+          height={20}
+          width={20}
+        >
+          <use
+            xlinkHref="#star"
+          />
+        </svg>
+      </i>
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/star-rating/__tests__/star-rating.test.js
+++ b/src/components/star-rating/__tests__/star-rating.test.js
@@ -1,0 +1,13 @@
+/* eslint-env jest */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import StarRating from '../star-rating.react';
+
+describe('StarRating', () => {
+  test('should render properly', () => {
+    const wrapper = renderer.create(<StarRating score={3.7} />).toJSON();
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/star-rating/star-rating.react.js
+++ b/src/components/star-rating/star-rating.react.js
@@ -9,11 +9,11 @@ import colors from '../../design-tokens/tokens';
 
 import styles from './star-rating.css';
 
-const DEFAULT_COLOR = '#f07a7a';
+const DEFAULT_COLOR = 'coral';
 
 function StarRating(props) {
   const {score = 0, className, color, ...otherProps} = props;
-  const starColor = color ? colors[color] : DEFAULT_COLOR;
+  const starColor = color ? colors[color] : colors[DEFAULT_COLOR];
 
   return (
     <UIBase


### PR DESCRIPTION
As #290 added the *coral* color to the basic color palette it uses that color instead of a hardcoded value for the default star-rating component.

It also adds a basic snapshot test.

![Screenshot 2019-05-23 at 18 55 47](https://user-images.githubusercontent.com/435399/58275214-6b43a700-7d8c-11e9-8c41-b9985740308e.png)


### How to test it
1. go to `site/`
1. `npm start` to start the style guide
1. go to http://localhost:8000/components/star-rating/
1. check that everything looks as before