### PR TITLE
added TooltipBox type info

### DIFF
--- a/src/components/tooltip-box/__examples__/tooltip-box.examples.js
+++ b/src/components/tooltip-box/__examples__/tooltip-box.examples.js
@@ -31,4 +31,12 @@ export const examples = [
       </div>
     ),
   },
+  {
+    title: 'TooltipBox Info',
+    render: () => (
+      <TooltipBox text="Hello! I am a tooltip" type="info">
+        Hover me :)
+      </TooltipBox>
+    ),
+  },
 ];

--- a/src/components/tooltip-box/__examples__/tooltip-box.examples.js
+++ b/src/components/tooltip-box/__examples__/tooltip-box.examples.js
@@ -38,5 +38,14 @@ export const examples = [
         Hover me :)
       </TooltipBox>
     ),
+    html: () => (
+      <div className="tooltip-container tooltip-container--info">
+        Hover me :){' '}
+        <svg aria-hidden="true" fill="currentColor" height={16} width={16}>
+          <use xlinkHref="#info_outline" />
+        </svg>
+        <div className="tooltip-bubble">Hello! I am a tooltip</div>
+      </div>
+    ),
   },
 ];

--- a/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
+++ b/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
@@ -5,8 +5,39 @@ exports[`TooltipBox should render properly - show right 1`] = `
   className="tooltip-container"
 >
   Hover me :)
+   
   <div
     className="tooltip-bubble tooltip-bubble--right"
+  >
+    Hello! I am a tooltip
+  </div>
+</div>
+`;
+
+exports[`TooltipBox should render properly - type info 1`] = `
+<div
+  className="tooltip-container tooltip-container--info"
+>
+  Hover me :)
+   
+  <i
+    className="ui-icon ui-icon--size-16 fill-currentColor e1krcyn16 css-0"
+    onClick={undefined}
+    style={Object {}}
+    title={undefined}
+  >
+    <svg
+      aria-hidden="true"
+      height={16}
+      width={16}
+    >
+      <use
+        xlinkHref="#info_outline"
+      />
+    </svg>
+  </i>
+  <div
+    className="tooltip-bubble"
   >
     Hello! I am a tooltip
   </div>
@@ -18,6 +49,7 @@ exports[`TooltipBox should render properly 1`] = `
   className="tooltip-container"
 >
   Hover me :)
+   
   <div
     className="tooltip-bubble"
   >

--- a/src/components/tooltip-box/__tests__/tooltip-box.test.js
+++ b/src/components/tooltip-box/__tests__/tooltip-box.test.js
@@ -22,4 +22,15 @@ describe('TooltipBox', () => {
       .toJSON();
     expect(wrapper).toMatchSnapshot();
   });
+
+  test('should render properly - type info', () => {
+    const wrapper = renderer
+      .create(
+        <TooltipBox text="Hello! I am a tooltip" type="info">
+          Hover me :)
+        </TooltipBox>
+      )
+      .toJSON();
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/components/tooltip-box/tooltip-box.css
+++ b/src/components/tooltip-box/tooltip-box.css
@@ -3,6 +3,14 @@
   display: inline-block;
 }
 
+.tooltip-container--info {
+  color: var(--blue700);
+  transition: color 0.2s ease-out;
+  &:hover {
+    color: var(--blue800);
+  }
+}
+
 .tooltip-bubble {
   position: absolute;
   bottom: 0;

--- a/src/components/tooltip-box/tooltip-box.react.js
+++ b/src/components/tooltip-box/tooltip-box.react.js
@@ -3,14 +3,26 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import styles from './tooltip-box.css';
+import Icon from '../icon';
 
 const SUPPORTED_DIRECTIONS = ['right'];
+const TYPE_ICON_MAP = {
+  info: 'info_outline',
+};
 
 const TooltipBox = props => {
-  const {children, text, show, className, ...otherProps} = props;
+  const {children, text, show, className, type, ...otherProps} = props;
+
+  const isTypeSupported = Boolean(TYPE_ICON_MAP[type]);
 
   const classnames = {
-    container: cx(styles['tooltip-container'], className),
+    container: cx(
+      styles['tooltip-container'],
+      {
+        [styles[`tooltip-container--${type}`]]: isTypeSupported,
+      },
+      className
+    ),
     bubble: cx(styles['tooltip-bubble'], {
       [styles[`tooltip-bubble--${show}`]]: SUPPORTED_DIRECTIONS.includes(show),
     }),
@@ -18,7 +30,10 @@ const TooltipBox = props => {
 
   return (
     <div className={classnames.container} {...otherProps}>
-      {children}
+      {children}{' '}
+      {isTypeSupported && (
+        <Icon color="currentColor">{TYPE_ICON_MAP[type]}</Icon>
+      )}
       <div className={classnames.bubble}>{text}</div>
     </div>
   );
@@ -37,6 +52,10 @@ TooltipBox.propTypes = {
    * the direction of the tooltip ['right'] (if not indicated pops from the bottom).
    */
   show: PropTypes.oneOf(['right']),
+  /**
+   * the type of the tooltip box ['info']
+   */
+  type: PropTypes.oneOf(['info']),
   className: PropTypes.string,
 };
 


### PR DESCRIPTION
Extended `TooltipBox` component to support `type="info"`.

**Behaviour:**
- apply blue color to text
- inherit other properties from surrounding text
- (i) icon at the end

![Screenshot 2019-05-28 at 10 36 08](https://user-images.githubusercontent.com/435399/58467928-7869e880-8134-11e9-80cc-29c1cf045995.png)

### How to test it
1. `npm install`
1. go to `site/`
1. `npm start` to start the style guide
1. go to http://localhost:8000/components/tooltip-box/