### PR TITLE
Fixed support for tooltip type node

### DIFF
--- a/src/components/tooltip-box/__examples__/tooltip-box.examples.js
+++ b/src/components/tooltip-box/__examples__/tooltip-box.examples.js
@@ -6,7 +6,7 @@ export const examples = [
   {
     title: 'TooltipBox',
     render: () => (
-      <TooltipBox text="Hello! I am a tooltip">Hover me :)</TooltipBox>
+      <TooltipBox tooltip="Hello! I am a tooltip">Hover me :)</TooltipBox>
     ),
     html: () => (
       <div className="tooltip-container">
@@ -16,9 +16,25 @@ export const examples = [
     ),
   },
   {
+    title: 'TooltipBox - Node',
+    render: () => (
+      <TooltipBox
+        tooltip={
+          <ul>
+            Hello!<li>I am</li>
+            <li>a</li>
+            <li>tooltip</li>
+          </ul>
+        }
+      >
+        Hover me :)
+      </TooltipBox>
+    ),
+  },
+  {
     title: 'TooltipBox - show right',
     render: () => (
-      <TooltipBox text="Hello! I am a tooltip" show="right">
+      <TooltipBox tooltip="Hello! I am a tooltip" show="right">
         Hover me :)
       </TooltipBox>
     ),
@@ -34,7 +50,7 @@ export const examples = [
   {
     title: 'TooltipBox Info',
     render: () => (
-      <TooltipBox text="Hello! I am a tooltip" type="info">
+      <TooltipBox tooltip="Hello! I am a tooltip" type="info">
         Hover me :)
       </TooltipBox>
     ),

--- a/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
+++ b/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
@@ -44,6 +44,31 @@ exports[`TooltipBox should render properly - type info 1`] = `
 </div>
 `;
 
+exports[`TooltipBox should render properly - with node tooltip 1`] = `
+<div
+  className="tooltip-container"
+>
+  Hover me :)
+   
+  <div
+    className="tooltip-bubble tooltip-bubble--right"
+  >
+    <ul>
+      Hello!
+      <li>
+        I am
+      </li>
+      <li>
+        a
+      </li>
+      <li>
+        tooltip
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
 exports[`TooltipBox should render properly 1`] = `
 <div
   className="tooltip-container"

--- a/src/components/tooltip-box/__tests__/tooltip-box.test.js
+++ b/src/components/tooltip-box/__tests__/tooltip-box.test.js
@@ -7,7 +7,29 @@ import TooltipBox from '../tooltip-box.react';
 describe('TooltipBox', () => {
   test('should render properly', () => {
     const wrapper = renderer
-      .create(<TooltipBox text="Hello! I am a tooltip">Hover me :)</TooltipBox>)
+      .create(
+        <TooltipBox tooltip="Hello! I am a tooltip">Hover me :)</TooltipBox>
+      )
+      .toJSON();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('should render properly - with node tooltip', () => {
+    const wrapper = renderer
+      .create(
+        <TooltipBox
+          tooltip={
+            <ul>
+              Hello!<li>I am</li>
+              <li>a</li>
+              <li>tooltip</li>
+            </ul>
+          }
+          show="right"
+        >
+          Hover me :)
+        </TooltipBox>
+      )
       .toJSON();
     expect(wrapper).toMatchSnapshot();
   });
@@ -15,7 +37,7 @@ describe('TooltipBox', () => {
   test('should render properly - show right', () => {
     const wrapper = renderer
       .create(
-        <TooltipBox text="Hello! I am a tooltip" show="right">
+        <TooltipBox tooltip="Hello! I am a tooltip" show="right">
           Hover me :)
         </TooltipBox>
       )
@@ -26,7 +48,7 @@ describe('TooltipBox', () => {
   test('should render properly - type info', () => {
     const wrapper = renderer
       .create(
-        <TooltipBox text="Hello! I am a tooltip" type="info">
+        <TooltipBox tooltip="Hello! I am a tooltip" type="info">
           Hover me :)
         </TooltipBox>
       )

--- a/src/components/tooltip-box/tooltip-box.react.js
+++ b/src/components/tooltip-box/tooltip-box.react.js
@@ -11,7 +11,7 @@ const TYPE_ICON_MAP = {
 };
 
 const TooltipBox = props => {
-  const {children, text, show, className, type, ...otherProps} = props;
+  const {children, tooltip, show, className, type, ...otherProps} = props;
 
   const isTypeSupported = Boolean(TYPE_ICON_MAP[type]);
 
@@ -34,16 +34,16 @@ const TooltipBox = props => {
       {isTypeSupported && (
         <Icon color="currentColor">{TYPE_ICON_MAP[type]}</Icon>
       )}
-      <div className={classnames.bubble}>{text}</div>
+      <div className={classnames.bubble}>{tooltip}</div>
     </div>
   );
 };
 
 TooltipBox.propTypes = {
   /**
-   * The text of the tooltip.
+   * The tooltip content.
    */
-  text: PropTypes.string.isRequired,
+  tooltip: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   /**
    * It's the element that triggers the visibility of the tooltip.
    */


### PR DESCRIPTION
Changed the prop name `text` -> `tooltip`.

Everything else it's exactly the same.

![Screenshot 2019-05-29 at 12 36 38](https://user-images.githubusercontent.com/435399/58554272-7411fe00-820e-11e9-93f5-8c581fb41925.png)
