### PR TITLE
Change info_outline to info icon - Create __content class

### DIFF
--- a/src/components/inline-alert/inline-alert.css
+++ b/src/components/inline-alert/inline-alert.css
@@ -5,11 +5,11 @@
   line-height: 1.6rem;
   background-color: pink;
   padding: 0.8rem 1.6rem;
+}
 
-  &__content {
-    padding-left: 8px;
-    padding-top: 2px;
-  }
+.ui-inline-alert__content {
+  padding-left: 8px;
+  padding-top: 2px;
 }
 
 .ui-inline-alert--info {

--- a/src/components/inline-alert/inline-alert.react.js
+++ b/src/components/inline-alert/inline-alert.react.js
@@ -8,7 +8,7 @@ import Icon from '../icon';
 import styles from './inline-alert.css';
 
 const TYPE_ICON_MAP = {
-  info: 'info_outline',
+  info: 'info',
   error: 'highlight_off',
   warning: 'error_outline',
   confirmation: 'check_circle',


### PR DESCRIPTION
I extracted the `&__content` class from `.ui-inline-alert` and created a new class `.ui-inline-alert__content` so the padding would apply to the text and icon within the `<InlineAlert />` component. Also change the `info_outline` icon to `info` icon.

### Background
Problem was the browser was not reading the `&__content`, therefore was not applying the necessary styles (padding). 
![info icon and no space - current](https://user-images.githubusercontent.com/14036745/58563127-7716e980-8222-11e9-89a6-b9a02a331987.png)

### Solution
Removed `&__content` and added the following below `.ui-inline-alert`:
```
.ui-inline-alert__content {
  padding-left: 8px;
  padding-top: 2px;
}
```
<img width="813" alt="Screenshot 2019-05-29 at 15 06 42" src="https://user-images.githubusercontent.com/14036745/58563637-674bd500-8223-11e9-85a2-4b70dff0dee8.png">


### How to verify
1. Check out this branch
2. `npm install` in `ui` root
3. `cd site`
4. `npm install`
5. `npm run start`



