### PR TITLE
Updated tooltip z-index

### DIFF
--- a/src/components/tooltip-box/tooltip-box.css
+++ b/src/components/tooltip-box/tooltip-box.css
@@ -28,7 +28,7 @@
   max-width: 260px;
   min-width: 200px;
   padding: 10px 20px;
-
+  z-index: 99999; /* Move to token */
   &:before {
     position: absolute;
     display: block;


### PR DESCRIPTION
The problem is that a generic `z-index` has not been defined.

This may cause issues like:

<img width="249" alt="Screenshot 2019-05-30 at 09 30 31" src="https://user-images.githubusercontent.com/435399/58621347-0c68bb00-82c1-11e9-999f-f79a3fa49da3.png">

Setting the `z-index` as the highest number supported (`modal.css`) fixes this issue.

<img width="247" alt="Screenshot 2019-05-30 at 09 30 41" src="https://user-images.githubusercontent.com/435399/58621383-2904f300-82c1-11e9-944a-cf99a4552fe3.png">

#### How to test it

1. Change one of the tooltip examples in `tooltip-box.examples.js` in:
```
<div>
  <TooltipBox
    tooltip="Hello! I am a tooltip"
    type="info"
  >
    Hover me :)
  </TooltipBox>
  <div
    style={{
      color: 'red',
      position: 'absolute'
    }}
  >
    info
  </div>
</div>
```

1. `cd site && npm start`
1. check that `tooltip` behaves as expected.