### PR TITLE
Disable cssnano zindex optimisation

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -18,6 +18,7 @@ module.exports = {
       core: false,
       minifyFontValues: false,
       discardUnused: false,
+      zindex: false,
     },
   },
 };

--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -129,7 +129,10 @@ exports.createPages = ({boundActionCreators, graphql}) => {
   const componentPageTemplate = path.resolve(`src/templates/component.js`);
   return graphql(`
     {
-      allMarkdownRemark(sort: {fields: [fields___componentName], order: ASC}, filter: {fields: {ignorePage: {eq: false}}}) {
+      allMarkdownRemark(
+        sort: {fields: [fields___componentName], order: ASC}
+        filter: {fields: {ignorePage: {eq: false}}}
+      ) {
         edges {
           node {
             fields {
@@ -191,6 +194,7 @@ exports.modifyWebpackConfig = ({config, stage}) => {
           core: false,
           minifyFontValues: false,
           discardUnused: false,
+          zindex: false,
         },
       }),
     ],


### PR DESCRIPTION
Prevent `cssnano` to redefine the `z-index` based on the presence on files.

The main problem is the `Tooltip` component needs to be the highest `z-index` value supported (in our case `99999`).

Related to #297.

#### How to test it
1. `npm run build`
1. `cat src/components/tooltip-box/tooltip-box.css| grep z-index` check that the value has been changed to `1`
1. checkout this branch
1. `npm run build`
1. `cat src/components/tooltip-box/tooltip-box.css| grep z-index` check that the value has not been changed