### PR TITLE
Fix tag group children flow definition

### DIFF
--- a/src/components/tag-group/tag-group.react.js
+++ b/src/components/tag-group/tag-group.react.js
@@ -41,7 +41,10 @@ const TagGroup = props => {
 };
 
 TagGroup.propTypes = {
-  children: PropTypes.array,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf([PropTypes.node]),
+    PropTypes.node,
+  ]),
   limit: PropTypes.number,
   showOverflow: PropTypes.bool,
   className: PropTypes.string,


### PR DESCRIPTION
Stop proptype errors when a single child is passed