### PR TITLE
Extended Tooltip component

### DIFF
--- a/src/components/tooltip-box/__examples__/tooltip-box.examples.js
+++ b/src/components/tooltip-box/__examples__/tooltip-box.examples.js
@@ -48,6 +48,20 @@ export const examples = [
     ),
   },
   {
+    title: 'TooltipBox - content width',
+    render: () => (
+      <TooltipBox tooltip="Hi!" contentWidth={true}>
+        Hover me :)
+      </TooltipBox>
+    ),
+    html: () => (
+      <div className="tooltip-container">
+        Hover me :)
+        <div className="tooltip-bubble tooltip-bubble--content-width">Hi!</div>
+      </div>
+    ),
+  },
+  {
     title: 'TooltipBox Info',
     render: () => (
       <TooltipBox tooltip="Hello! I am a tooltip" type="info">

--- a/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
+++ b/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TooltipBox should render properly - content width 1`] = `
+<div
+  className="tooltip-container"
+>
+  Hover me :)
+   
+  <div
+    className="tooltip-bubble tooltip-bubble--content-width"
+  >
+    Hello! I am a tooltip
+  </div>
+</div>
+`;
+
 exports[`TooltipBox should render properly - show right 1`] = `
 <div
   className="tooltip-container"

--- a/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
+++ b/src/components/tooltip-box/__tests__/__snapshots__/tooltip-box.test.js.snap
@@ -14,6 +14,20 @@ exports[`TooltipBox should render properly - content width 1`] = `
 </div>
 `;
 
+exports[`TooltipBox should render properly - extend bubble classname 1`] = `
+<div
+  className="tooltip-container"
+>
+  Hover me :)
+   
+  <div
+    className="tooltip-bubble foo"
+  >
+    Hello! I am a tooltip
+  </div>
+</div>
+`;
+
 exports[`TooltipBox should render properly - show right 1`] = `
 <div
   className="tooltip-container"

--- a/src/components/tooltip-box/__tests__/tooltip-box.test.js
+++ b/src/components/tooltip-box/__tests__/tooltip-box.test.js
@@ -55,4 +55,15 @@ describe('TooltipBox', () => {
       .toJSON();
     expect(wrapper).toMatchSnapshot();
   });
+
+  test('should render properly - content width', () => {
+    const wrapper = renderer
+      .create(
+        <TooltipBox tooltip="Hello! I am a tooltip" contentWidth={true}>
+          Hover me :)
+        </TooltipBox>
+      )
+      .toJSON();
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/components/tooltip-box/__tests__/tooltip-box.test.js
+++ b/src/components/tooltip-box/__tests__/tooltip-box.test.js
@@ -66,4 +66,15 @@ describe('TooltipBox', () => {
       .toJSON();
     expect(wrapper).toMatchSnapshot();
   });
+
+  test('should render properly - extend bubble classname', () => {
+    const wrapper = renderer
+      .create(
+        <TooltipBox tooltip="Hello! I am a tooltip" bubbleClassName="foo">
+          Hover me :)
+        </TooltipBox>
+      )
+      .toJSON();
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/components/tooltip-box/tooltip-box.module.css
+++ b/src/components/tooltip-box/tooltip-box.module.css
@@ -68,3 +68,9 @@
 .tooltip-container:hover .tooltip-bubble--right {
   transform: translate3d(calc(100% + 8px), -50%, 0);
 }
+
+.tooltip-bubble--content-width {
+  min-width: auto;
+  max-width: none;
+  white-space: nowrap;
+}

--- a/src/components/tooltip-box/tooltip-box.react.js
+++ b/src/components/tooltip-box/tooltip-box.react.js
@@ -16,6 +16,7 @@ const TooltipBox = props => {
     tooltip,
     show,
     className,
+    bubbleClassName,
     contentWidth,
     type,
     ...otherProps
@@ -39,6 +40,7 @@ const TooltipBox = props => {
         ),
         [styles[`tooltip-bubble--content-width`]]: contentWidth,
       },
+      bubbleClassName
     ),
   };
 
@@ -74,6 +76,10 @@ TooltipBox.propTypes = {
    * adapt the width to its content
    */
   contentWidth: PropTypes.bool,
+  /**
+   * className given to the tooltip bubble
+   */
+  bubbleClassName: PropTypes.string,
   className: PropTypes.string,
 };
 

--- a/src/components/tooltip-box/tooltip-box.react.js
+++ b/src/components/tooltip-box/tooltip-box.react.js
@@ -11,7 +11,15 @@ const TYPE_ICON_MAP = {
 };
 
 const TooltipBox = props => {
-  const {children, tooltip, show, className, type, ...otherProps} = props;
+  const {
+    children,
+    tooltip,
+    show,
+    className,
+    contentWidth,
+    type,
+    ...otherProps
+  } = props;
 
   const isTypeSupported = Boolean(TYPE_ICON_MAP[type]);
 
@@ -23,9 +31,15 @@ const TooltipBox = props => {
       },
       className
     ),
-    bubble: cx(styles['tooltip-bubble'], {
-      [styles[`tooltip-bubble--${show}`]]: SUPPORTED_DIRECTIONS.includes(show),
-    }),
+    bubble: cx(
+      styles['tooltip-bubble'],
+      {
+        [styles[`tooltip-bubble--${show}`]]: SUPPORTED_DIRECTIONS.includes(
+          show
+        ),
+        [styles[`tooltip-bubble--content-width`]]: contentWidth,
+      },
+    ),
   };
 
   return (
@@ -56,6 +70,10 @@ TooltipBox.propTypes = {
    * the type of the tooltip box ['info']
    */
   type: PropTypes.oneOf(['info']),
+  /**
+   * adapt the width to its content
+   */
+  contentWidth: PropTypes.bool,
   className: PropTypes.string,
 };
 


### PR DESCRIPTION
In detail:
- added `contentWidth` prop to `TooltipBox` component
- added possibility to extend `TooltipBox` bubble `className` using `bubbleClassName` prop

__before:__
<img width="216" alt="Screenshot 2019-06-12 at 17 10 41" src="https://user-images.githubusercontent.com/435399/59368480-3a74e300-8d36-11e9-800e-e8b10372bedf.png">

__after:__
<img width="144" alt="Screenshot 2019-06-12 at 17 09 54" src="https://user-images.githubusercontent.com/435399/59368497-41035a80-8d36-11e9-9917-65d316941e66.png">
