### PR TITLE
Remove safari prefixer

### DIFF
--- a/src/utils/__tests__/style.test.js
+++ b/src/utils/__tests__/style.test.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+
+import {parseStyleProps} from '../style';
+
+describe('utlis/style', () => {
+  describe('parseStyleProps', () => {
+    it('should properly filter styles', () => {
+      const originalProps = {
+        foo: 'bar',
+        asd: {qwe: 123},
+        margin: '10px',
+        style: {
+          display: 'flex',
+        },
+      };
+
+      expect(parseStyleProps(originalProps)).toEqual({
+        props: {
+          asd: {
+            qwe: 123,
+          },
+          foo: 'bar',
+        },
+        style: {
+          display: 'flex',
+          margin: '10px',
+        },
+      });
+    });
+
+    it('should extend prop style', () => {
+      const originalProps = {
+        foo: 'bar',
+        asd: {qwe: 123},
+        margin: '10px',
+      };
+
+      expect(parseStyleProps(originalProps)).toEqual({
+        props: {
+          asd: {
+            qwe: 123,
+          },
+          foo: 'bar',
+        },
+        style: {
+          margin: '10px',
+        },
+      });
+    });
+  });
+});

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -51,22 +51,17 @@ export function parseStyle(name, value) {
 }
 
 /** Pull out styles from props */
-export function parseStyleProps(originalProps) {
-  const props = {};
-  const style = originalProps.style || {};
-
-  for (const key in originalProps) {
-    if ({}.hasOwnProperty.call(originalProps, key)) {
-      if (STYLE_WHITELIST[key]) {
-        style[key] = parseStyle(key, originalProps[key]);
-      } else if (key !== 'style') {
-        props[key] = originalProps[key];
-      }
-    }
-  }
-
-  return {props, style};
-}
+export const parseStyleProps = ({style = {}, ...otherProps}) =>
+  Object.keys(otherProps).reduce(
+    (parsed, key) =>
+      STYLE_WHITELIST[key]
+        ? {
+            ...parsed,
+            style: {...parsed.style, [key]: parseStyle(key, otherProps[key])},
+          }
+        : {...parsed, props: {...parsed.props, [key]: otherProps[key]}},
+    {props: {}, style}
+  );
 
 export function stylePropTransform(originalProps) {
   const props = {};

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -32,34 +32,6 @@ export function cleanProps(originalProps) {
   return cleanedProps;
 }
 
-/**
- * Flexbox style overrides for Safari 8
- * Safari 8 detection is performed in advance
- */
-const VENDOR_STYLERS =
-  typeof window !== 'undefined' &&
-  window.navigator.userAgent.indexOf('Safari/') !== -1 &&
-  window.navigator.userAgent.indexOf('Version/8') !== -1
-    ? {
-        display: (key, value) => ({
-          key,
-          value: (value.indexOf('flex') > -1 ? '-webkit-' : '') + value,
-        }),
-        alignContent: (key, value) => ({key: 'WebkitAlignContent', value}),
-        alignItems: (key, value) => ({key: 'WebkitAlignItems', value}),
-        alignSelf: (key, value) => ({key: 'WebkitAlignSelf', value}),
-        justifyContent: (key, value) => ({key: 'WebkitJustifyContent', value}),
-        order: (key, value) => ({key: 'WebkitOrder', value}),
-        flexDirection: (key, value) => ({key: 'WebkitFlexDirection', value}),
-        flexWrap: (key, value) => ({key: 'WebkitFlexWrap', value}),
-        flexFlow: (key, value) => ({key: 'WebkitFlexFlow', value}),
-        flex: (key, value) => ({key: 'WebkitFlex', value}),
-        flexBasis: (key, value) => ({key: 'WebkitFlexBasis', value}),
-        flexShrink: (key, value) => ({key: 'WebkitFlexShrink', value}),
-        flexGrow: (key, value) => ({key: 'WebkitFlexGrow', value}),
-      }
-    : {};
-
 /** Parse a specific style */
 export function parseStyle(name, value) {
   if (value && SPACING_REGEX.test(name)) {
@@ -86,13 +58,7 @@ export function parseStyleProps(originalProps) {
   for (const key in originalProps) {
     if ({}.hasOwnProperty.call(originalProps, key)) {
       if (STYLE_WHITELIST[key]) {
-        const parsedStyleValue = parseStyle(key, originalProps[key]);
-        if (!!VENDOR_STYLERS[key]) {
-          const pair = VENDOR_STYLERS[key](key, parsedStyleValue);
-          style[pair.key] = pair.value;
-        } else {
-          style[key] = parsedStyleValue;
-        }
+        style[key] = parseStyle(key, originalProps[key]);
       } else if (key !== 'style') {
         props[key] = originalProps[key];
       }


### PR DESCRIPTION
Removed custom prefixer for Safari 8 (that is no longer supported).

This check is affecting every single prop used by UI components and this PR removes a bunch of unnecessary checks.

#### How to verify
1. Check out this branch
1. `cd site && npm start`
1. Check that everything looks good
